### PR TITLE
Collapse older news and research items behind a toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -261,6 +261,18 @@
                             I: <a href="https://indico.ihep.ac.cn/event/24761/">Large Jet Models Workshop</a> at Peking
                             University,
                             Beijing, China<br>
+                        </p>
+
+                        <div class="text-center">
+                            <button class="btn btn-outline-secondary btn-sm" type="button" data-toggle="collapse"
+                                data-target="#olderNews" aria-expanded="false" aria-controls="olderNews"
+                                id="olderNewsToggle">
+                                Show older news
+                            </button>
+                        </div>
+
+                        <div class="collapse" id="olderNews">
+                        <p style="font-size:15px">
                             <br>
                             <b>December 15, 2024</b>: Subash presents "Learning Symmetry-Independent Jet Representations
                             via
@@ -668,6 +680,8 @@
                                 href="http://ml4physicalsciences.github.io/2019/">2nd Machine Learning and the Physical
                                 Sciences
                                 Workshop</a> at NeurIPS 2019.
+                        </p>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -691,6 +705,13 @@
     <script src="vendor/jquery/jquery.min.js"></script>
     <script src="vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
 
+    <script>
+        $('#olderNews').on('show.bs.collapse', function () {
+            $('#olderNewsToggle').text('Show fewer news items');
+        }).on('hide.bs.collapse', function () {
+            $('#olderNewsToggle').text('Show older news');
+        });
+    </script>
 
 </body>
 

--- a/research.html
+++ b/research.html
@@ -370,6 +370,15 @@
           <br>Code: <a href="https://github.com/JavierZhao/JetCLR">https://github.com/JavierZhao/JetCLR</a>
       </div>
     </div>
+
+    <div class="text-center my-4">
+      <button class="btn btn-outline-secondary" type="button" data-toggle="collapse" data-target="#olderResearch"
+        aria-expanded="false" aria-controls="olderResearch" id="olderResearchToggle">
+        Show older research
+      </button>
+    </div>
+
+    <div class="collapse" id="olderResearch">
     <div class="row">
       <div class="col-lg-6">
         <img class="img-fluid rounded mb-4" src="images/HIG-23-012_1.png" alt="" width="500">
@@ -1264,6 +1273,7 @@
             href="https://github.com/fastmachinelearning/hls4ml">https://github.com/fastmachinelearning/hls4ml</a>
       </div>
     </div>
+    </div>
     <!-- /.row -->
 
   </div>
@@ -1280,6 +1290,14 @@
   <!-- Bootstrap core JavaScript -->
   <script src="vendor/jquery/jquery.min.js"></script>
   <script src="vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
+
+  <script>
+    $('#olderResearch').on('show.bs.collapse', function () {
+      $('#olderResearchToggle').text('Show fewer research items');
+    }).on('hide.bs.collapse', function () {
+      $('#olderResearchToggle').text('Show older research');
+    });
+  </script>
 
 </body>
 


### PR DESCRIPTION
## Summary
- `index.html`'s News card and `research.html` had grown into a long scroll (82 news items back to 2019, 49 research entries) with no way to see what's recent without scrolling past years of history.
- Show the 2025-2026 news items and the 10 most recent research entries by default; collapse everything older behind a "Show older ..." button (Bootstrap collapse, already loaded via `bootstrap.bundle.min.js` — no new dependencies) that expands in place and swaps its label to "Show fewer ..." items.

## Test plan
- [x] Verified in-browser on both pages: default (collapsed) state, expand, and collapse-back-to-default all render correctly
- [x] Confirmed via JS that the button text toggles between "Show older ..." / "Show fewer ... items" on expand/collapse
- [x] Diffed the change to confirm no existing content was dropped or reordered — purely additive markup

🤖 Generated with [Claude Code](https://claude.com/claude-code)