### PR TITLE
Collapse older news and research items behind a toggle

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -8,3 +8,17 @@
 <!-- Bootstrap core JavaScript -->
 <script src="{{ '/vendor/jquery/jquery.min.js' | relative_url }}"></script>
 <script src="{{ '/vendor/bootstrap/js/bootstrap.bundle.min.js' | relative_url }}"></script>
+
+<!-- Toggle labels for any "Show older ..." collapse sections on the page -->
+<script>
+  $('[data-collapse-toggle-label]').each(function () {
+    var $toggle = $(this);
+    var $target = $($toggle.data('collapse-toggle-label'));
+    if (!$target.length) return;
+    $target.on('show.bs.collapse', function () {
+      $toggle.text($toggle.data('expanded-label'));
+    }).on('hide.bs.collapse', function () {
+      $toggle.text($toggle.data('collapsed-label'));
+    });
+  });
+</script>

--- a/index.html
+++ b/index.html
@@ -192,6 +192,19 @@ active_nav: about
             I: <a href="https://indico.ihep.ac.cn/event/24761/">Large Jet Models Workshop</a> at Peking
             University,
             Beijing, China<br>
+          </p>
+
+          <div class="text-center">
+            <button class="btn btn-outline-secondary btn-sm" type="button" data-toggle="collapse"
+              data-target="#olderNews" aria-expanded="false" aria-controls="olderNews"
+              data-collapse-toggle-label="#olderNews" data-collapsed-label="Show older news"
+              data-expanded-label="Show fewer news items">
+              Show older news
+            </button>
+          </div>
+
+          <div class="collapse" id="olderNews">
+          <p style="font-size:15px">
             <br>
             <b>December 15, 2024</b>: Subash presents "Learning Symmetry-Independent Jet Representations
             via
@@ -599,6 +612,8 @@ active_nav: about
               href="http://ml4physicalsciences.github.io/2019/">2nd Machine Learning and the Physical
               Sciences
               Workshop</a> at NeurIPS 2019.
+          </p>
+          </div>
         </div>
       </div>
     </div>

--- a/research.html
+++ b/research.html
@@ -303,6 +303,16 @@ title: Research
           <br>Code: <a href="https://github.com/JavierZhao/JetCLR">https://github.com/JavierZhao/JetCLR</a>
       </div>
     </div>
+
+    <div class="text-center my-4">
+      <button class="btn btn-outline-secondary" type="button" data-toggle="collapse" data-target="#olderResearch"
+        aria-expanded="false" aria-controls="olderResearch" data-collapse-toggle-label="#olderResearch"
+        data-collapsed-label="Show older research" data-expanded-label="Show fewer research items">
+        Show older research
+      </button>
+    </div>
+
+    <div class="collapse" id="olderResearch">
     <div class="row">
       <div class="col-lg-6">
         <img class="img-fluid rounded mb-4" src="images/HIG-23-012_1.png" alt="" width="500">
@@ -1196,6 +1206,7 @@ title: Research
           <br>Code: <a
             href="https://github.com/fastmachinelearning/hls4ml">https://github.com/fastmachinelearning/hls4ml</a>
       </div>
+    </div>
     </div>
     <!-- /.row -->
 


### PR DESCRIPTION
## Summary
- `index.html`'s News card and `research.html` had grown into a long scroll (82 news items back to 2019, 49 research entries) with no way to see what's recent without scrolling past years of history.
- Show the 2025-2026 news items and the 10 most recent research entries by default; collapse everything older behind a "Show older ..." button (Bootstrap collapse, already loaded via `bootstrap.bundle.min.js` — no new dependencies) that expands in place and swaps its label to "Show fewer ..." items.
- The toggle-label script lives once in `_includes/footer.html`, driven by `data-collapse-toggle-label`/`data-collapsed-label`/`data-expanded-label` attributes on the trigger button, rather than duplicated per page. It no-ops safely on pages with neither collapse section (verified no console errors on `teaching.html`).

Supersedes #37, which was based on `gh-pages` from before the Jekyll migration merged and no longer applies cleanly.

## Test plan
- [x] Local Jekyll build + serve, verified both pages render correctly
- [x] Verified via browser JS that both toggles expand/collapse and swap label text correctly
- [x] Verified the shared footer script produces no console errors on a page with neither collapse section
- [x] Diffed the change to confirm no existing content was dropped or reordered — purely additive markup

🤖 Generated with [Claude Code](https://claude.com/claude-code)