### PR TITLE
Add CI workflow to test Jekyll build on PRs to gh-pages

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -1,0 +1,28 @@
+name: Test Jekyll build
+
+on:
+  pull_request:
+    branches: [gh-pages]
+
+concurrency:
+  group: test-build-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+
+      - name: Build site
+        run: bundle exec jekyll build


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/test-build.yml`: runs `bundle exec jekyll build` on every pull request targeting `gh-pages`.
- Catches a broken Liquid tag, bad front matter, or missing include as a failing PR check, instead of only surfacing after merge (or after `deploy.yml`'s build step fails during an actual deploy).
- Needs no secrets (unlike `deploy.yml`, which needs `DEPLOY_SSH_KEY`), so it also runs cleanly on PRs from forks.

## Test plan
- [x] Validated the workflow YAML parses correctly
- [x] Ran the equivalent build command (`bundle exec jekyll build`) locally to confirm it currently succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)